### PR TITLE
Enhancement/client functional opts

### DIFF
--- a/brfc.go
+++ b/brfc.go
@@ -26,10 +26,10 @@ type BRFCSpec struct {
 //
 // additionSpecifications is appended to the default specs
 // BRFCKnownSpecifications is a local constant of JSON to pre-load known BRFC ids
-func (c *ClientOptions) LoadBRFCs(additionalSpecifications string) (err error) {
+func (c *clientOptions) LoadBRFCs(additionalSpecifications string) (err error) {
 
 	// Load the default specs
-	if err = json.Unmarshal([]byte(BRFCKnownSpecifications), &c.BRFCSpecs); err != nil {
+	if err = json.Unmarshal([]byte(BRFCKnownSpecifications), &c.brfcSpecs); err != nil {
 		// This error case should never occur since the JSON is hardcoded, but good practice anyway
 		return
 	}
@@ -59,7 +59,7 @@ func (c *ClientOptions) LoadBRFCs(additionalSpecifications string) (err error) {
 		}
 
 		// Add to existing list
-		c.BRFCSpecs = append(c.BRFCSpecs, spec)
+		c.brfcSpecs = append(c.brfcSpecs, spec)
 	}
 
 	return

--- a/brfc_test.go
+++ b/brfc_test.go
@@ -162,19 +162,19 @@ func TestClientOptions_LoadBRFCs(t *testing.T) {
 		expectedLength int
 		expectedError  bool
 	}{
-		{`[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`, len(client.Options.brfcSpecs) + 1, false},
-		{`[{"invalid:1}]`, len(client.Options.brfcSpecs), true},
-		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":"invalid-spec","id": "17dd1f54fc66"}]`, len(client.Options.brfcSpecs), true},
-		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":""}]`, len(client.Options.brfcSpecs), true},
+		{`[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`, len(client.options.brfcSpecs) + 1, false},
+		{`[{"invalid:1}]`, len(client.options.brfcSpecs), true},
+		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":"invalid-spec","id": "17dd1f54fc66"}]`, len(client.options.brfcSpecs), true},
+		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":""}]`, len(client.options.brfcSpecs), true},
 	}
 
 	for _, test := range tests {
-		if err = client.Options.LoadBRFCs(test.specJSON); err != nil && !test.expectedError {
+		if err = client.options.LoadBRFCs(test.specJSON); err != nil && !test.expectedError {
 			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs and error not expected but got: %s", t.Name(), test.specJSON, test.expectedLength, err.Error())
 		} else if err == nil && test.expectedError {
 			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs and error was expected", t.Name(), test.specJSON, test.expectedLength)
-		} else if len(client.Options.brfcSpecs) != test.expectedLength {
-			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs but got: %d", t.Name(), test.specJSON, test.expectedLength, len(client.Options.brfcSpecs))
+		} else if len(client.options.brfcSpecs) != test.expectedLength {
+			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs but got: %d", t.Name(), test.specJSON, test.expectedLength, len(client.options.brfcSpecs))
 		}
 	}
 }
@@ -182,9 +182,10 @@ func TestClientOptions_LoadBRFCs(t *testing.T) {
 // ExampleClientOptions_LoadBRFCs example using LoadBRFCs()
 //
 // See more examples in /examples/
+// nolint:govet // options are now private but example still useful.
 func ExampleClientOptions_LoadBRFCs() {
 	// Create a client with options
-	client, err := NewClient(nil, nil, nil)
+	client, err := NewClient()
 	if err != nil {
 		fmt.Printf("error loading client: %s", err.Error())
 		return
@@ -192,11 +193,11 @@ func ExampleClientOptions_LoadBRFCs() {
 
 	// Load additional specification(s)
 	additionalSpec := `[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`
-	if err = client.Options.LoadBRFCs(additionalSpec); err != nil {
+	if err = client.options.LoadBRFCs(additionalSpec); err != nil {
 		fmt.Printf("error occurred: %s", err.Error())
 		return
 	}
-	fmt.Printf("total specifications found: %d", len(client.Options.brfcSpecs))
+	fmt.Printf("total specifications found: %d", len(client.options.brfcSpecs))
 
 	// Output:total specifications found: 20
 }
@@ -206,6 +207,6 @@ func BenchmarkClientOptions_LoadBRFCs(b *testing.B) {
 	client, _ := NewClient(nil, nil, nil)
 	additionalSpec := `[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`
 	for i := 0; i < b.N; i++ {
-		_ = client.Options.LoadBRFCs(additionalSpec)
+		_ = client.options.LoadBRFCs(additionalSpec)
 	}
 }

--- a/brfc_test.go
+++ b/brfc_test.go
@@ -162,10 +162,10 @@ func TestClientOptions_LoadBRFCs(t *testing.T) {
 		expectedLength int
 		expectedError  bool
 	}{
-		{`[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`, len(client.Options.BRFCSpecs) + 1, false},
-		{`[{"invalid:1}]`, len(client.Options.BRFCSpecs), true},
-		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":"invalid-spec","id": "17dd1f54fc66"}]`, len(client.Options.BRFCSpecs), true},
-		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":""}]`, len(client.Options.BRFCSpecs), true},
+		{`[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`, len(client.Options.brfcSpecs) + 1, false},
+		{`[{"invalid:1}]`, len(client.Options.brfcSpecs), true},
+		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":"invalid-spec","id": "17dd1f54fc66"}]`, len(client.Options.brfcSpecs), true},
+		{`[{"author": "andy (nChain), Ryan X. Charles (Money Button)","title":""}]`, len(client.Options.brfcSpecs), true},
 	}
 
 	for _, test := range tests {
@@ -173,8 +173,8 @@ func TestClientOptions_LoadBRFCs(t *testing.T) {
 			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs and error not expected but got: %s", t.Name(), test.specJSON, test.expectedLength, err.Error())
 		} else if err == nil && test.expectedError {
 			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs and error was expected", t.Name(), test.specJSON, test.expectedLength)
-		} else if len(client.Options.BRFCSpecs) != test.expectedLength {
-			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs but got: %d", t.Name(), test.specJSON, test.expectedLength, len(client.Options.BRFCSpecs))
+		} else if len(client.Options.brfcSpecs) != test.expectedLength {
+			t.Errorf("%s Failed: [%s] inputted, [%d] expected specs but got: %d", t.Name(), test.specJSON, test.expectedLength, len(client.Options.brfcSpecs))
 		}
 	}
 }
@@ -196,7 +196,7 @@ func ExampleClientOptions_LoadBRFCs() {
 		fmt.Printf("error occurred: %s", err.Error())
 		return
 	}
-	fmt.Printf("total specifications found: %d", len(client.Options.BRFCSpecs))
+	fmt.Printf("total specifications found: %d", len(client.Options.brfcSpecs))
 
 	// Output:total specifications found: 20
 }

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -21,8 +21,7 @@ func TestClient_GetCapabilities(t *testing.T) {
 
 		mockCapabilities(http.StatusOK)
 
-		var capabilities *Capabilities
-		capabilities, err = client.GetCapabilities(testDomain, DefaultPort)
+		capabilities, err := client.GetCapabilities(testDomain, DefaultPort)
 		assert.NoError(t, err)
 		assert.NotNil(t, capabilities)
 		assert.Equal(t, DefaultBsvAliasVersion, capabilities.BsvAlias)

--- a/client.go
+++ b/client.go
@@ -10,55 +10,127 @@ import (
 
 // Client is the paymail client/configuration
 type Client struct {
-	Options  *ClientOptions    `json:"options"` // Options are all the default settings / configuration
-	Resolver ResolverInterface `json:"-"`       // Resolver is used for DNS lookups
-	Resty    *resty.Client     `json:"-"`       // Resty HTTP client for outgoing requests
+	options *clientOptions `json:"options"` // Options are all the default settings / configuration
 }
 
 // ClientOptions holds all the configuration for client requests and default resources
-type ClientOptions struct {
-	BRFCSpecs         []*BRFCSpec `json:"brfc_specs"`          // List of BRFC specifications
-	DNSPort           string      `json:"dns_port"`            // Default DNS port for SRV checks
-	DNSTimeout        int         `json:"dns_timeout"`         // Default timeout in seconds for DNS fetching
-	GetTimeout        int         `json:"get_timeout"`         // Default timeout in seconds for GET requests
-	NameServer        string      `json:"name_server"`         // Default name server for DNS checks
-	NameServerNetwork string      `json:"name_server_network"` // Default name server network
-	PostTimeout       int         `json:"post_timeout"`        // Default timeout in seconds for POST requests
-	RequestTracing    bool        `json:"request_tracing"`     // If enabled, it will trace the request timing
-	RetryCount        int         `json:"retry_count"`         // Default retry count for HTTP requests
-	SSLDeadline       int         `json:"ssl_deadline"`        // Default timeout in seconds for SSL deadline
-	SSLTimeout        int         `json:"ssl_timeout"`         // Default timeout in seconds for SSL timeout
-	UserAgent         string      `json:"user_agent"`          // User agent for all outgoing requests
+type clientOptions struct {
+	brfcSpecs         []*BRFCSpec   `json:"brfc_specs"`          // List of BRFC specifications
+	dnsPort           string        `json:"dns_port"`            // Default DNS port for SRV checks
+	dnsTimeout        time.Duration `json:"dns_timeout"`         // Default timeout in seconds for DNS fetching
+	httpTimeout       time.Duration `json:"get_timeout"`         // Default timeout in seconds for GET requests
+	nameServer        string        `json:"name_server"`         // Default name server for DNS checks
+	nameServerNetwork string        `json:"name_server_network"` // Default name server network
+	requestTracing    bool          `json:"request_tracing"`     // If enabled, it will trace the request timing
+	retryCount        int           `json:"retry_count"`         // Default retry count for HTTP requests
+	sslDeadline       time.Duration `json:"ssl_deadline"`        // Default timeout in seconds for SSL deadline
+	sslTimeout        time.Duration `json:"ssl_timeout"`         // Default timeout in seconds for SSL timeout
+	userAgent         string        `json:"user_agent"`          // User agent for all outgoing requests
+	resolver          DNSResolver   `json:"-"`
+	httpClient        *resty.Client `json:"-"`
 }
 
-// DefaultClientOptions will return an Options struct with the default settings
+type ClientOps func(c *clientOptions)
+
+func WithDNSPort(port string) ClientOps {
+	return func(c *clientOptions) {
+		c.dnsPort = port
+	}
+}
+
+func WithDNSTimeout(timeout time.Duration) ClientOps {
+	return func(c *clientOptions) {
+		c.dnsTimeout = timeout
+	}
+}
+func WithBRFCSpecs(specs []*BRFCSpec) ClientOps {
+	return func(c *clientOptions) {
+		c.brfcSpecs = specs
+	}
+}
+
+func WithHttpTimeout(timeout time.Duration) ClientOps {
+	return func(c *clientOptions) {
+		c.httpTimeout = timeout
+	}
+}
+
+func WithNameServer(ip string) ClientOps {
+	return func(c *clientOptions) {
+		c.nameServer = ip
+	}
+}
+func WithNameServerNetwork(network string) ClientOps {
+	return func(c *clientOptions) {
+		c.nameServerNetwork = network
+	}
+}
+
+func WithRequestTracing() ClientOps {
+	return func(c *clientOptions) {
+		c.requestTracing = true
+	}
+}
+func WithRetryCount(retries int) ClientOps {
+	return func(c *clientOptions) {
+		c.retryCount = retries
+	}
+}
+
+func WithSSLTimeout(timeout time.Duration) ClientOps {
+	return func(c *clientOptions) {
+		c.sslTimeout = timeout
+	}
+}
+
+func WithSSLDeadline(timeout time.Duration) ClientOps {
+	return func(c *clientOptions) {
+		c.sslDeadline = timeout
+	}
+}
+
+func WithUserAgent(userAgent string) ClientOps {
+	return func(c *clientOptions) {
+		c.userAgent = userAgent
+	}
+}
+
+func WithCustomResolver(resolver DNSResolver) ClientOps {
+	return func(c *clientOptions) {
+		c.resolver = resolver
+	}
+}
+
+func WithCustomHttpClient(client *resty.Client) ClientOps {
+	return func(c *clientOptions) {
+		c.httpClient = client
+	}
+}
+
+// defaultClientOptions will return an Options struct with the default settings
 //
 // Useful for starting with the default and then modifying as needed
-func DefaultClientOptions() (clientOptions *ClientOptions, err error) {
-
+func defaultClientOptions() (opts *clientOptions, err error) {
 	// Set the default options
-	clientOptions = &ClientOptions{
-		DNSPort:           defaultDNSPort,
-		DNSTimeout:        defaultDNSTimeout,
-		GetTimeout:        defaultGetTimeout,
-		NameServer:        defaultNameServer,
-		NameServerNetwork: defaultNameServerNetwork,
-		PostTimeout:       defaultPostTimeout,
-		RequestTracing:    false,
-		RetryCount:        defaultRetryCount,
-		SSLDeadline:       defaultSSLDeadline,
-		SSLTimeout:        defaultSSLTimeout,
-		UserAgent:         defaultUserAgent,
+	opts = &clientOptions{
+		dnsPort:           defaultDNSPort,
+		dnsTimeout:        defaultDNSTimeout,
+		httpTimeout:       defaultHttpTimeout,
+		nameServer:        defaultNameServer,
+		nameServerNetwork: defaultNameServerNetwork,
+		requestTracing:    false,
+		retryCount:        defaultRetryCount,
+		sslDeadline:       defaultSSLDeadline,
+		sslTimeout:        defaultSSLTimeout,
+		userAgent:         defaultUserAgent,
 	}
-
 	// Load the default BRFC specs
-	err = clientOptions.LoadBRFCs("")
-
+	err = opts.LoadBRFCs("")
 	return
 }
 
-// ResolverInterface is a custom resolver interface for testing
-type ResolverInterface interface {
+// DNSResolver is a custom resolver interface for testing
+type DNSResolver interface {
 	LookupHost(ctx context.Context, host string) ([]string, error)
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
@@ -68,111 +140,85 @@ type ResolverInterface interface {
 //
 // If no options are given, it will use the DefaultClientOptions()
 // If no client is supplied it will use a default Resty HTTP client
-func NewClient(clientOptions *ClientOptions, customClient *resty.Client,
-	customResolver ResolverInterface) (client *Client, err error) {
-
+func NewClient(opts ...ClientOps) (*Client, error) {
+	defaults, err := defaultClientOptions()
+	if err != nil {
+		return nil, err
+	}
 	// Create a new client
-	client = new(Client)
-
-	// Set default options if none are provided
-	if clientOptions == nil {
-		clientOptions, err = DefaultClientOptions()
-	} else {
+	client := &Client{
+		options: defaults,
+	}
+	// overwrite defaults with any set by user
+	for _, opt := range opts {
+		opt(client.options)
+	}
+	// default brfcs
+	if len(client.options.brfcSpecs) == 0 {
 		// Check for specs (if not set, use the defaults)
-		if len(clientOptions.BRFCSpecs) == 0 {
-			if err = clientOptions.LoadBRFCs(""); err != nil {
-				// This error case should not occur since it's unmarshalling a JSON constant
-				return
-			}
+		if err := client.options.LoadBRFCs(""); err != nil {
+			return nil, err
 		}
 	}
-
-	// Set the client options
-	client.Options = clientOptions
-
 	// Set the resolver
-	if customResolver != nil {
-		client.Resolver = customResolver
-	} else {
+	if client.options.resolver == nil {
 		r := client.defaultResolver()
-		client.Resolver = &r
+		client.options.resolver = &r
 	}
-
 	// Set the Resty HTTP client
-	if customClient != nil {
-		client.Resty = customClient
-	} else {
-		client.Resty = resty.New()
-
+	if client.options.httpClient == nil {
+		client.options.httpClient = resty.New()
 		// Set defaults (for GET requests)
-		client.Resty.SetTimeout(time.Duration(client.Options.GetTimeout) * time.Second)
-		client.Resty.SetRetryCount(client.Options.RetryCount)
+		client.options.httpClient.SetTimeout(time.Duration(client.options.httpTimeout) * time.Second)
+		client.options.httpClient.SetRetryCount(client.options.retryCount)
 	}
-
-	return
+	return client, nil
 }
 
 // getRequest is a standard GET request for all outgoing HTTP requests
 func (c *Client) getRequest(requestURL string) (response StandardResponse, err error) {
-
 	// Set the user agent
-	req := c.Resty.R().SetHeader("User-Agent", c.Options.UserAgent)
-
+	req := c.Options.httpClient.R().SetHeader("User-Agent", c.Options.userAgent)
 	// Enable tracing
-	if c.Options.RequestTracing {
+	if c.Options.requestTracing {
 		req.EnableTrace()
 	}
-
 	// Fire the request
 	var resp *resty.Response
 	if resp, err = req.Get(requestURL); err != nil {
 		return
 	}
-
 	// Tracing enabled?
-	if c.Options.RequestTracing {
+	if c.Options.requestTracing {
 		response.Tracing = resp.Request.TraceInfo()
 	}
-
 	// Set the status code
 	response.StatusCode = resp.StatusCode()
-
 	// Set the body
 	response.Body = resp.Body()
-
 	return
 }
 
 // postRequest is a standard PORT request for all outgoing HTTP requests
 func (c *Client) postRequest(requestURL string, data interface{}) (response StandardResponse, err error) {
-
-	// Set POST defaults
-	c.Resty.SetTimeout(time.Duration(c.Options.PostTimeout) * time.Second)
-
 	// Set the user agent
-	req := c.Resty.R().SetBody(data).SetHeader("User-Agent", c.Options.UserAgent)
-
+	req := c.Options.httpClient.R().SetBody(data).SetHeader("User-Agent", c.Options.userAgent)
 	// Enable tracing
-	if c.Options.RequestTracing {
+	if c.Options.requestTracing {
 		req.EnableTrace()
 	}
-
 	// Fire the request
 	var resp *resty.Response
 	if resp, err = req.Post(requestURL); err != nil {
 		return
 	}
-
 	// Tracing enabled?
-	if c.Options.RequestTracing {
+	if c.Options.requestTracing {
 		response.Tracing = resp.Request.TraceInfo()
 	}
-
 	// Set the status code
 	response.StatusCode = resp.StatusCode()
-
 	// Set the body
 	response.Body = resp.Body()
-
 	return
 }

--- a/client_test.go
+++ b/client_test.go
@@ -26,19 +26,12 @@ func newTestClient() (*Client, error) {
 	}
 
 	// Set test options
-	options.RequestTracing = true
-	options.DNSTimeout = 15
-
-	// Create a new client
-	var newClient *Client
-	newClient, err = NewClient(options, client, nil)
-	if err != nil {
-		return nil, err
-	}
+	options.requestTracing = true
+	options.dnsTimeout = 15
 
 	// Set the customer resolver with known defaults
 	r := newCustomResolver(
-		newClient.Resolver,
+		newClient.Options.resolver,
 		map[string][]string{
 			testDomain:      {"44.225.125.175", "35.165.117.200", "54.190.182.236"},
 			"norecords.com": {},
@@ -54,9 +47,13 @@ func newTestClient() (*Client, error) {
 		},
 	)
 
+	// Create a new client
+	newClient, err := NewClient(WithRequestTracing(), WithDNSTimeout(15*time.Second))
+	if err != nil {
+		return nil, err
+	}
 	// Set the custom resolver
 	newClient.Resolver = r
-
 	// Return the mocking client
 	return newClient, nil
 }
@@ -69,19 +66,19 @@ func TestNewClient(t *testing.T) {
 		client, err := NewClient(nil, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
-		assert.Equal(t, defaultDNSTimeout, client.Options.DNSTimeout)
-		assert.Equal(t, defaultDNSPort, client.Options.DNSPort)
+		assert.Equal(t, defaultDNSTimeout, client.Options.dnsTimeout)
+		assert.Equal(t, defaultDNSPort, client.Options.dnsPort)
 		assert.Equal(t, defaultUserAgent, client.Options.UserAgent)
 		assert.Equal(t, defaultNameServerNetwork, client.Options.NameServerNetwork)
 		assert.Equal(t, defaultNameServer, client.Options.NameServer)
 		assert.Equal(t, defaultSSLTimeout, client.Options.SSLTimeout)
 		assert.Equal(t, defaultSSLDeadline, client.Options.SSLDeadline)
-		assert.Equal(t, defaultGetTimeout, client.Options.GetTimeout)
+		assert.Equal(t, defaultGetTimeout, client.Options.getTimeout)
 		assert.Equal(t, defaultRetryCount, client.Options.RetryCount)
 		assert.Equal(t, false, client.Options.RequestTracing)
 		assert.Equal(t, defaultPostTimeout, client.Options.PostTimeout)
-		assert.NotEqual(t, 0, len(client.Options.BRFCSpecs))
-		assert.Greater(t, len(client.Options.BRFCSpecs), 6)
+		assert.NotEqual(t, 0, len(client.Options.brfcSpecs))
+		assert.Greater(t, len(client.Options.brfcSpecs), 6)
 	})
 
 	t.Run("custom http client", func(t *testing.T) {
@@ -117,7 +114,7 @@ func TestNewClient(t *testing.T) {
 		assert.NotNil(t, options)
 
 		// Remove the specs (empty)
-		options.BRFCSpecs = nil
+		options.brfcSpecs = nil
 
 		var client *Client
 		client, err = NewClient(options, nil, nil)
@@ -154,19 +151,19 @@ func TestDefaultClientOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, options)
 
-	assert.Equal(t, defaultDNSTimeout, options.DNSTimeout)
-	assert.Equal(t, defaultDNSPort, options.DNSPort)
+	assert.Equal(t, defaultDNSTimeout, options.dnsTimeout)
+	assert.Equal(t, defaultDNSPort, options.dnsPort)
 	assert.Equal(t, defaultUserAgent, options.UserAgent)
 	assert.Equal(t, defaultNameServerNetwork, options.NameServerNetwork)
 	assert.Equal(t, defaultNameServer, options.NameServer)
 	assert.Equal(t, defaultSSLTimeout, options.SSLTimeout)
 	assert.Equal(t, defaultSSLDeadline, options.SSLDeadline)
-	assert.Equal(t, defaultGetTimeout, options.GetTimeout)
+	assert.Equal(t, defaultGetTimeout, options.getTimeout)
 	assert.Equal(t, defaultRetryCount, options.RetryCount)
 	assert.Equal(t, false, options.RequestTracing)
 	assert.Equal(t, defaultPostTimeout, options.PostTimeout)
-	assert.NotEqual(t, 0, len(options.BRFCSpecs))
-	assert.Greater(t, len(options.BRFCSpecs), 6)
+	assert.NotEqual(t, 0, len(options.brfcSpecs))
+	assert.Greater(t, len(options.brfcSpecs), 6)
 }
 
 // ExampleDefaultClientOptions example using DefaultClientOptions()

--- a/client_test.go
+++ b/client_test.go
@@ -19,19 +19,15 @@ func newTestClient() (*Client, error) {
 	// Get the underlying HTTP Client and set it to Mock
 	httpmock.ActivateNonDefault(client.GetClient())
 
-	// Set options
-	options, err := DefaultClientOptions()
+	// Create a new client
+	newClient, err := NewClient(WithRequestTracing(), WithDNSTimeout(15*time.Second))
 	if err != nil {
 		return nil, err
 	}
-
-	// Set test options
-	options.requestTracing = true
-	options.dnsTimeout = 15
-
+	newClient.WithCustomHTTPClient(client)
 	// Set the customer resolver with known defaults
 	r := newCustomResolver(
-		newClient.Options.resolver,
+		newClient.resolver,
 		map[string][]string{
 			testDomain:      {"44.225.125.175", "35.165.117.200", "54.190.182.236"},
 			"norecords.com": {},
@@ -47,13 +43,8 @@ func newTestClient() (*Client, error) {
 		},
 	)
 
-	// Create a new client
-	newClient, err := NewClient(WithRequestTracing(), WithDNSTimeout(15*time.Second))
-	if err != nil {
-		return nil, err
-	}
 	// Set the custom resolver
-	newClient.Resolver = r
+	newClient.WithCustomResolver(r)
 	// Return the mocking client
 	return newClient, nil
 }
@@ -63,61 +54,50 @@ func TestNewClient(t *testing.T) {
 	t.Parallel()
 
 	t.Run("default client", func(t *testing.T) {
-		client, err := NewClient(nil, nil, nil)
+		client, err := NewClient()
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
-		assert.Equal(t, defaultDNSTimeout, client.Options.dnsTimeout)
-		assert.Equal(t, defaultDNSPort, client.Options.dnsPort)
-		assert.Equal(t, defaultUserAgent, client.Options.UserAgent)
-		assert.Equal(t, defaultNameServerNetwork, client.Options.NameServerNetwork)
-		assert.Equal(t, defaultNameServer, client.Options.NameServer)
-		assert.Equal(t, defaultSSLTimeout, client.Options.SSLTimeout)
-		assert.Equal(t, defaultSSLDeadline, client.Options.SSLDeadline)
-		assert.Equal(t, defaultGetTimeout, client.Options.getTimeout)
-		assert.Equal(t, defaultRetryCount, client.Options.RetryCount)
-		assert.Equal(t, false, client.Options.RequestTracing)
-		assert.Equal(t, defaultPostTimeout, client.Options.PostTimeout)
-		assert.NotEqual(t, 0, len(client.Options.brfcSpecs))
-		assert.Greater(t, len(client.Options.brfcSpecs), 6)
+		assert.Equal(t, defaultDNSTimeout, client.options.dnsTimeout)
+		assert.Equal(t, defaultDNSPort, client.options.dnsPort)
+		assert.Equal(t, defaultUserAgent, client.options.userAgent)
+		assert.Equal(t, defaultNameServerNetwork, client.options.nameServerNetwork)
+		assert.Equal(t, defaultNameServer, client.options.nameServer)
+		assert.Equal(t, defaultSSLTimeout, client.options.sslTimeout)
+		assert.Equal(t, defaultSSLDeadline, client.options.sslDeadline)
+		assert.Equal(t, defaultHTTPTimeout, client.options.httpTimeout)
+		assert.Equal(t, defaultRetryCount, client.options.retryCount)
+		assert.Equal(t, false, client.options.requestTracing)
+		assert.NotEqual(t, 0, len(client.options.brfcSpecs))
+		assert.Greater(t, len(client.options.brfcSpecs), 6)
 	})
 
 	t.Run("custom http client", func(t *testing.T) {
 		customHTTPClient := resty.New()
-		customHTTPClient.SetTimeout(defaultGetTimeout * time.Second)
-		client, err := NewClient(nil, customHTTPClient, nil)
-		assert.NotNil(t, client)
+		customHTTPClient.SetTimeout(defaultHTTPTimeout)
+		client, err := NewClient()
 		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		client.WithCustomHTTPClient(customHTTPClient)
 	})
 
 	t.Run("custom options", func(t *testing.T) {
-		options, err := DefaultClientOptions()
-		assert.NotNil(t, options)
-		assert.NoError(t, err)
-		options.UserAgent = "custom user agent"
-
 		var client *Client
-		client, err = NewClient(options, nil, nil)
+		client, err := NewClient(WithUserAgent("custom user agent"))
 		assert.NotNil(t, client)
 		assert.NoError(t, err)
 	})
 
 	t.Run("custom resolver", func(t *testing.T) {
 		r := newCustomResolver(nil, nil, nil, nil)
-		client, err := NewClient(nil, nil, r)
+		client, err := NewClient()
 		assert.NotNil(t, client)
 		assert.NoError(t, err)
+		client.WithCustomResolver(r)
 	})
 
 	t.Run("no brfcs", func(t *testing.T) {
-		options, err := DefaultClientOptions()
-		assert.NoError(t, err)
-		assert.NotNil(t, options)
-
-		// Remove the specs (empty)
-		options.brfcSpecs = nil
-
 		var client *Client
-		client, err = NewClient(options, nil, nil)
+		client, err := NewClient(WithBRFCSpecs(nil))
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
 	})
@@ -127,12 +107,12 @@ func TestNewClient(t *testing.T) {
 //
 // See more examples in /examples/
 func ExampleNewClient() {
-	client, err := NewClient(nil, nil, nil)
+	client, err := NewClient()
 	if err != nil {
 		fmt.Printf("error loading client: %s", err.Error())
 		return
 	}
-	fmt.Printf("loaded client: %s", client.Options.UserAgent)
+	fmt.Printf("loaded client: %s", client.options.userAgent)
 	// Output:loaded client: go-paymail: v0.1.6
 }
 
@@ -147,21 +127,20 @@ func BenchmarkNewClient(b *testing.B) {
 func TestDefaultClientOptions(t *testing.T) {
 	t.Parallel()
 
-	options, err := DefaultClientOptions()
+	options, err := defaultClientOptions()
 	assert.NoError(t, err)
 	assert.NotNil(t, options)
 
 	assert.Equal(t, defaultDNSTimeout, options.dnsTimeout)
 	assert.Equal(t, defaultDNSPort, options.dnsPort)
-	assert.Equal(t, defaultUserAgent, options.UserAgent)
-	assert.Equal(t, defaultNameServerNetwork, options.NameServerNetwork)
-	assert.Equal(t, defaultNameServer, options.NameServer)
-	assert.Equal(t, defaultSSLTimeout, options.SSLTimeout)
-	assert.Equal(t, defaultSSLDeadline, options.SSLDeadline)
-	assert.Equal(t, defaultGetTimeout, options.getTimeout)
-	assert.Equal(t, defaultRetryCount, options.RetryCount)
-	assert.Equal(t, false, options.RequestTracing)
-	assert.Equal(t, defaultPostTimeout, options.PostTimeout)
+	assert.Equal(t, defaultUserAgent, options.userAgent)
+	assert.Equal(t, defaultNameServerNetwork, options.nameServerNetwork)
+	assert.Equal(t, defaultNameServer, options.nameServer)
+	assert.Equal(t, defaultSSLTimeout, options.sslTimeout)
+	assert.Equal(t, defaultSSLDeadline, options.sslDeadline)
+	assert.Equal(t, defaultHTTPTimeout, options.httpTimeout)
+	assert.Equal(t, defaultRetryCount, options.retryCount)
+	assert.Equal(t, false, options.requestTracing)
 	assert.NotEqual(t, 0, len(options.brfcSpecs))
 	assert.Greater(t, len(options.brfcSpecs), 6)
 }
@@ -169,19 +148,20 @@ func TestDefaultClientOptions(t *testing.T) {
 // ExampleDefaultClientOptions example using DefaultClientOptions()
 //
 // See more examples in /examples/
+// nolint:govet // opts are now private
 func ExampleDefaultClientOptions() {
-	options, err := DefaultClientOptions()
+	options, err := defaultClientOptions()
 	if err != nil {
 		fmt.Printf("error loading options: %s", err.Error())
 		return
 	}
-	fmt.Printf("loaded options: %s", options.UserAgent)
+	fmt.Printf("loaded options: %s", options.userAgent)
 	// Output:loaded options: go-paymail: v0.1.6
 }
 
 // BenchmarkDefaultClientOptions benchmarks the method DefaultClientOptions()
 func BenchmarkDefaultClientOptions(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _ = DefaultClientOptions()
+		_, _ = defaultClientOptions()
 	}
 }

--- a/definitions.go
+++ b/definitions.go
@@ -11,8 +11,8 @@ import (
 // Defaults for paymail functions
 const (
 	defaultDNSPort           = "53"                     // Default port for DNS / NameServer checks
-	defaultDNSTimeout        = 5                        // In seconds
-	defaultHttpTimeout       = 20 * time.Second         // Default timeout for all GET requests in seconds
+	defaultDNSTimeout        = 5 * time.Second          // In seconds
+	defaultHTTPTimeout       = 20 * time.Second         // Default timeout for all GET requests in seconds
 	defaultNameServer        = "8.8.8.8"                // Default DNS NameServer
 	defaultNameServerNetwork = "udp"                    // Default for NS dialer
 	defaultRetryCount        = 2                        // Default retry count for HTTP requests

--- a/definitions.go
+++ b/definitions.go
@@ -1,6 +1,10 @@
 package paymail
 
-import "github.com/go-resty/resty/v2"
+import (
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
 
 // version is the current package version
 
@@ -8,13 +12,12 @@ import "github.com/go-resty/resty/v2"
 const (
 	defaultDNSPort           = "53"                     // Default port for DNS / NameServer checks
 	defaultDNSTimeout        = 5                        // In seconds
-	defaultGetTimeout        = 15                       // Default timeout for all GET requests in seconds
+	defaultHttpTimeout       = 20 * time.Second         // Default timeout for all GET requests in seconds
 	defaultNameServer        = "8.8.8.8"                // Default DNS NameServer
 	defaultNameServerNetwork = "udp"                    // Default for NS dialer
-	defaultPostTimeout       = 25                       // Default timeout for all POST requests in seconds
 	defaultRetryCount        = 2                        // Default retry count for HTTP requests
-	defaultSSLDeadline       = 10                       // Default deadline in seconds
-	defaultSSLTimeout        = 10                       // Default timeout in seconds
+	defaultSSLDeadline       = 10 * time.Second         // Default deadline in seconds
+	defaultSSLTimeout        = 10 * time.Second         // Default timeout in seconds
 	defaultUserAgent         = "go-paymail: " + version // Default user agent
 	version                  = "v0.1.6"                 // Go-Paymail version
 )

--- a/dns_sec.go
+++ b/dns_sec.go
@@ -121,21 +121,21 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Set the registry name server
 	var registryNameserver string
-	if registryNameserver, err = resolveOneNS(tld, c.Options.NameServer, c.Options.dnsPort); err != nil {
+	if registryNameserver, err = resolveOneNS(tld, c.options.nameServer, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveOneNS: %s", err.Error())
 		return
 	}
 
 	// Set the domain name server
 	var domainNameserver string
-	if domainNameserver, err = resolveOneNS(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
+	if domainNameserver, err = resolveOneNS(domain, c.options.nameServer, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveOneNS: %s", err.Error())
 		return
 	}
 
 	// Domain name servers at registrar Host
 	var domainDsRecord []*domainDS
-	if domainDsRecord, err = resolveDomainDS(domain, registryNameserver, c.Options.dnsPort); err != nil {
+	if domainDsRecord, err = resolveDomainDS(domain, registryNameserver, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainDS: %s", err.Error())
 		return
 	}
@@ -146,7 +146,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve domain DNSKey
 	var dnsKey []*domainDNSKEY
-	if dnsKey, err = resolveDomainDNSKEY(domain, domainNameserver, c.Options.dnsPort); err != nil {
+	if dnsKey, err = resolveDomainDNSKEY(domain, domainNameserver, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainDNSKEY: %s", err.Error())
 		return
 	}
@@ -164,7 +164,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 	// Check the DS record
 	if result.Answer.DSRecordCount > 0 && result.Answer.DNSKEYRecordCount > 0 {
 		var calculatedDS []*domainDS
-		if calculatedDS, err = calculateDSRecord(domain, domainNameserver, c.Options.dnsPort, digest); err != nil {
+		if calculatedDS, err = calculateDSRecord(domain, domainNameserver, c.options.dnsPort, digest); err != nil {
 			result.ErrorMessage = fmt.Sprintf("failed in calculateDSRecord: %s", err.Error())
 			return
 		}
@@ -173,7 +173,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC
 	var nsec *dns.NSEC
-	if nsec, err = resolveDomainNSEC(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
+	if nsec, err = resolveDomainNSEC(domain, c.options.nameServer, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC: %s", err.Error())
 		return
 	} else if nsec != nil {
@@ -183,7 +183,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC3
 	var nsec3 *dns.NSEC3
-	if nsec3, err = resolveDomainNSEC3(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
+	if nsec3, err = resolveDomainNSEC3(domain, c.options.nameServer, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC3: %s", err.Error())
 		return
 	} else if nsec3 != nil {
@@ -193,7 +193,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC3PARAM
 	var nsec3param *dns.NSEC3PARAM
-	if nsec3param, err = resolveDomainNSEC3PARAM(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
+	if nsec3param, err = resolveDomainNSEC3PARAM(domain, c.options.nameServer, c.options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC3PARAM: %s", err.Error())
 		return
 	} else if nsec3param != nil {

--- a/dns_sec.go
+++ b/dns_sec.go
@@ -121,21 +121,21 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Set the registry name server
 	var registryNameserver string
-	if registryNameserver, err = resolveOneNS(tld, c.Options.NameServer, c.Options.DNSPort); err != nil {
+	if registryNameserver, err = resolveOneNS(tld, c.Options.NameServer, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveOneNS: %s", err.Error())
 		return
 	}
 
 	// Set the domain name server
 	var domainNameserver string
-	if domainNameserver, err = resolveOneNS(domain, c.Options.NameServer, c.Options.DNSPort); err != nil {
+	if domainNameserver, err = resolveOneNS(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveOneNS: %s", err.Error())
 		return
 	}
 
 	// Domain name servers at registrar Host
 	var domainDsRecord []*domainDS
-	if domainDsRecord, err = resolveDomainDS(domain, registryNameserver, c.Options.DNSPort); err != nil {
+	if domainDsRecord, err = resolveDomainDS(domain, registryNameserver, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainDS: %s", err.Error())
 		return
 	}
@@ -146,7 +146,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve domain DNSKey
 	var dnsKey []*domainDNSKEY
-	if dnsKey, err = resolveDomainDNSKEY(domain, domainNameserver, c.Options.DNSPort); err != nil {
+	if dnsKey, err = resolveDomainDNSKEY(domain, domainNameserver, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainDNSKEY: %s", err.Error())
 		return
 	}
@@ -164,7 +164,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 	// Check the DS record
 	if result.Answer.DSRecordCount > 0 && result.Answer.DNSKEYRecordCount > 0 {
 		var calculatedDS []*domainDS
-		if calculatedDS, err = calculateDSRecord(domain, domainNameserver, c.Options.DNSPort, digest); err != nil {
+		if calculatedDS, err = calculateDSRecord(domain, domainNameserver, c.Options.dnsPort, digest); err != nil {
 			result.ErrorMessage = fmt.Sprintf("failed in calculateDSRecord: %s", err.Error())
 			return
 		}
@@ -173,7 +173,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC
 	var nsec *dns.NSEC
-	if nsec, err = resolveDomainNSEC(domain, c.Options.NameServer, c.Options.DNSPort); err != nil {
+	if nsec, err = resolveDomainNSEC(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC: %s", err.Error())
 		return
 	} else if nsec != nil {
@@ -183,7 +183,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC3
 	var nsec3 *dns.NSEC3
-	if nsec3, err = resolveDomainNSEC3(domain, c.Options.NameServer, c.Options.DNSPort); err != nil {
+	if nsec3, err = resolveDomainNSEC3(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC3: %s", err.Error())
 		return
 	} else if nsec3 != nil {
@@ -193,7 +193,7 @@ func (c *Client) CheckDNSSEC(domain string) (result *DNSCheckResult) {
 
 	// Resolve the domain NSEC3PARAM
 	var nsec3param *dns.NSEC3PARAM
-	if nsec3param, err = resolveDomainNSEC3PARAM(domain, c.Options.NameServer, c.Options.DNSPort); err != nil {
+	if nsec3param, err = resolveDomainNSEC3PARAM(domain, c.Options.NameServer, c.Options.dnsPort); err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed in resolveDomainNSEC3PARAM: %s", err.Error())
 		return
 	} else if nsec3param != nil {

--- a/dns_sec_test.go
+++ b/dns_sec_test.go
@@ -53,7 +53,7 @@ func TestClient_CheckDNSSEC(t *testing.T) {
 //
 // See more examples in /examples/
 func ExampleClient_CheckDNSSEC() {
-	client, _ := NewClient(nil, nil, nil)
+	client, _ := NewClient()
 	results := client.CheckDNSSEC("google.com")
 	if len(results.ErrorMessage) == 0 {
 		fmt.Printf("valid DNSSEC found for: %s", "google.com")

--- a/examples/client/check_ssl/check_ssl.go
+++ b/examples/client/check_ssl/check_ssl.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/get_capabilities/get_capabilities.go
+++ b/examples/client/get_capabilities/get_capabilities.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/get_capabilities_value/get_capabilities_value.go
+++ b/examples/client/get_capabilities_value/get_capabilities_value.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/get_pki/get_pki.go
+++ b/examples/client/get_pki/get_pki.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/get_public_profile/get_public_profile.go
+++ b/examples/client/get_public_profile/get_public_profile.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/get_srv_record/get_srv_record.go
+++ b/examples/client/get_srv_record/get_srv_record.go
@@ -10,7 +10,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/has_capabilities/has_capabilities.go
+++ b/examples/client/has_capabilities/has_capabilities.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/load_additional_brfc/load_additional_brfc.go
+++ b/examples/client/load_additional_brfc/load_additional_brfc.go
@@ -9,15 +9,12 @@ import (
 func main() {
 
 	// Create a client with options
-	client, err := paymail.NewClient(nil, nil, nil)
+
+	// Load additional specification(s)
+	additionalSpec := `[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`
+	_, err := paymail.NewClient(paymail.WithUserAgent(additionalSpec))
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}
 
-	// Load additional specification(s)
-	additionalSpec := `[{"author": "andy (nChain)","id": "57dd1f54fc67","title": "BRFC Specifications","url": "http://bsvalias.org/01-02-brfc-id-assignment.html","version": "1"}]`
-	if err = client.Options.LoadBRFCs(additionalSpec); err != nil {
-		log.Fatalf("error occurred: %s", err.Error())
-	}
-	log.Printf("total specifications loaded: %d", len(client.Options.brfcSpecs))
 }

--- a/examples/client/load_additional_brfc/load_additional_brfc.go
+++ b/examples/client/load_additional_brfc/load_additional_brfc.go
@@ -19,5 +19,5 @@ func main() {
 	if err = client.Options.LoadBRFCs(additionalSpec); err != nil {
 		log.Fatalf("error occurred: %s", err.Error())
 	}
-	log.Printf("total specifications loaded: %d", len(client.Options.BRFCSpecs))
+	log.Printf("total specifications loaded: %d", len(client.Options.brfcSpecs))
 }

--- a/examples/client/p2p_payment_destination/p2p_payment_destination.go
+++ b/examples/client/p2p_payment_destination/p2p_payment_destination.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/p2p_send_transaction/p2p_send_transaction.go
+++ b/examples/client/p2p_send_transaction/p2p_send_transaction.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/resolve_address/resolve_address.go
+++ b/examples/client/resolve_address/resolve_address.go
@@ -10,7 +10,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/validate_srv_record/validate_srv_record.go
+++ b/examples/client/validate_srv_record/validate_srv_record.go
@@ -11,7 +11,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/examples/client/verify_pubkey/verify_pubkey.go
+++ b/examples/client/verify_pubkey/verify_pubkey.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	// Load the client
-	client, err := paymail.NewClient(nil, nil, nil)
+	client, err := paymail.NewClient()
 	if err != nil {
 		log.Fatalf("error loading client: %s", err.Error())
 	}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -10,13 +10,13 @@ import (
 type resolver struct {
 	hosts        map[string][]string
 	ipAddresses  map[string][]net.IPAddr
-	liveResolver ResolverInterface
+	liveResolver DNSResolver
 	srvRecords   map[string][]*net.SRV
 }
 
 // newCustomResolver will return a custom resolver with specific records hard coded ,
-func newCustomResolver(liveResolver ResolverInterface, hosts map[string][]string,
-	srvRecords map[string][]*net.SRV, ipAddresses map[string][]net.IPAddr) ResolverInterface {
+func newCustomResolver(liveResolver DNSResolver, hosts map[string][]string,
+	srvRecords map[string][]*net.SRV, ipAddresses map[string][]net.IPAddr) DNSResolver {
 	return &resolver{
 		hosts:        hosts,
 		ipAddresses:  ipAddresses,

--- a/srv.go
+++ b/srv.go
@@ -17,10 +17,10 @@ func (c *Client) defaultResolver() net.Resolver {
 		StrictErrors: false,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			d := net.Dialer{
-				Timeout: time.Second * time.Duration(c.Options.DNSTimeout),
+				Timeout: time.Second * time.Duration(c.Options.dnsTimeout),
 			}
 			return d.DialContext(
-				ctx, c.Options.NameServerNetwork, c.Options.NameServer+":"+c.Options.DNSPort,
+				ctx, c.Options.nameServerNetwork, c.Options.nameServer+":"+c.Options.dnsPort,
 			)
 		},
 	}
@@ -30,7 +30,6 @@ func (c *Client) defaultResolver() net.Resolver {
 //
 // Specs: http://bsvalias.org/02-01-host-discovery.html
 func (c *Client) GetSRVRecord(service, protocol, domainName string) (srv *net.SRV, err error) {
-
 	// Invalid parameters?
 	if len(service) == 0 { // Use the default from paymail specs
 		service = DefaultServiceName
@@ -50,7 +49,7 @@ func (c *Client) GetSRVRecord(service, protocol, domainName string) (srv *net.SR
 	// Lookup the SRV record
 	var cname string
 	var records []*net.SRV
-	if cname, records, err = c.Resolver.LookupSRV(
+	if cname, records, err = c.Options.resolver.LookupSRV(
 		context.Background(), service, protocol, domainName,
 	); err != nil {
 		return
@@ -109,7 +108,7 @@ func (c *Client) ValidateSRVRecord(ctx context.Context, srv *net.SRV, port, prio
 	}
 
 	// Test resolving the target
-	if addresses, err := c.Resolver.LookupHost(ctx, srv.Target); err != nil {
+	if addresses, err := c.Options.resolver.LookupHost(ctx, srv.Target); err != nil {
 		return err
 	} else if len(addresses) == 0 {
 		return fmt.Errorf("srv target %s could not resolve a host", srv.Target)

--- a/srv.go
+++ b/srv.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 )
 
 // defaultResolver will return a custom dns resolver
@@ -17,10 +16,10 @@ func (c *Client) defaultResolver() net.Resolver {
 		StrictErrors: false,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			d := net.Dialer{
-				Timeout: time.Second * time.Duration(c.Options.dnsTimeout),
+				Timeout: c.options.dnsTimeout,
 			}
 			return d.DialContext(
-				ctx, c.Options.nameServerNetwork, c.Options.nameServer+":"+c.Options.dnsPort,
+				ctx, c.options.nameServerNetwork, c.options.nameServer+":"+c.options.dnsPort,
 			)
 		},
 	}
@@ -49,7 +48,7 @@ func (c *Client) GetSRVRecord(service, protocol, domainName string) (srv *net.SR
 	// Lookup the SRV record
 	var cname string
 	var records []*net.SRV
-	if cname, records, err = c.Options.resolver.LookupSRV(
+	if cname, records, err = c.resolver.LookupSRV(
 		context.Background(), service, protocol, domainName,
 	); err != nil {
 		return
@@ -108,7 +107,7 @@ func (c *Client) ValidateSRVRecord(ctx context.Context, srv *net.SRV, port, prio
 	}
 
 	// Test resolving the target
-	if addresses, err := c.Options.resolver.LookupHost(ctx, srv.Target); err != nil {
+	if addresses, err := c.resolver.LookupHost(ctx, srv.Target); err != nil {
 		return err
 	} else if len(addresses) == 0 {
 		return fmt.Errorf("srv target %s could not resolve a host", srv.Target)

--- a/ssl.go
+++ b/ssl.go
@@ -15,7 +15,7 @@ func (c *Client) CheckSSL(host string) (valid bool, err error) {
 
 	// Lookup the host
 	var ips []net.IPAddr
-	if ips, err = c.Resolver.LookupIPAddr(context.Background(), host); err != nil {
+	if ips, err = c.resolver.LookupIPAddr(context.Background(), host); err != nil {
 		return
 	}
 
@@ -25,8 +25,8 @@ func (c *Client) CheckSSL(host string) (valid bool, err error) {
 
 			// Set the dialer
 			dialer := net.Dialer{
-				Timeout:  time.Duration(c.Options.SSLTimeout) * time.Second,
-				Deadline: time.Now().Add(time.Duration(c.Options.SSLDeadline) * time.Second),
+				Timeout:  c.options.sslTimeout,
+				Deadline: time.Now().Add(c.options.sslDeadline),
 			}
 
 			// Set the connection

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -60,7 +60,7 @@ func TestClient_CheckSSL(t *testing.T) {
 //
 // See more examples in /examples/
 func ExampleClient_CheckSSL() {
-	client, _ := NewClient(nil, nil, nil)
+	client, _ := NewClient()
 	valid, _ := client.CheckSSL("google.com")
 	if valid {
 		fmt.Printf("valid SSL certificate found for: %s", "google.com")


### PR DESCRIPTION
This updates the library to add functional options to setup a client, before we had to do `NewClient(nil.nil.nil)` to setup a default client, this could leave users wondering what these options are and if they're required or not. This change now means a default paymail client is simply NewClient().

To overwrite defaults there are a set of With.. options than can be passed to `NewClient(WithHTTPTimeout(30 * time.Second), WithRetries(10))`.

Custom resolver and httpclient s can be added like this: 

```go
client, err := NewClient()
client.WithCustomResolver(r)
client.WithCustomHttpClient(c)
```

All of the options and their settings have also been made private to reduce the size of the public api - this has resulted in the change touching quite a few files.