### PR TITLE
Enhancement: Bitcoin network support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dist
 
 # Converage
 coverage.txt
+
+# vim
+*.swp

--- a/capabilities.go
+++ b/capabilities.go
@@ -91,8 +91,8 @@ func (c *Client) GetCapabilities(target string, port int) (response *Capabilitie
 	}
 
 	// Set the base url and path
-	// https://<host-discovery-target>:<host-discovery-port>/.well-known/bsvalias
-	reqURL := fmt.Sprintf("https://%s:%d/.well-known/%s", target, port, DefaultServiceName)
+	// https://<host-discovery-target>:<host-discovery-port>/.well-known/bsvalias[network]
+	reqURL := fmt.Sprintf("https://%s:%d/.well-known/%s%s", target, port, DefaultServiceName, c.options.network.PaymailURLSuffix())
 
 	// Fire the GET request
 	var resp StandardResponse

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -27,6 +27,32 @@ func TestClient_GetCapabilities(t *testing.T) {
 		assert.Equal(t, true, response.Has(BRFCPki, ""))
 	})
 
+	t.Run("successful testnet response", func(t *testing.T) {
+		client := newTestClient(t, WithNetwork(Testnet))
+
+		mockCapabilitiesNetwork(http.StatusOK, Testnet)
+
+		response, err := client.GetCapabilities(testDomain, DefaultPort)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Equal(t, DefaultBsvAliasVersion, response.BsvAlias)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Equal(t, true, response.Has(BRFCPki, ""))
+	})
+
+	t.Run("successful stn response", func(t *testing.T) {
+		client := newTestClient(t, WithNetwork(STN))
+
+		mockCapabilitiesNetwork(http.StatusOK, STN)
+
+		response, err := client.GetCapabilities(testDomain, DefaultPort)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Equal(t, DefaultBsvAliasVersion, response.BsvAlias)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Equal(t, true, response.Has(BRFCPki, ""))
+	})
+
 	t.Run("status not modified", func(t *testing.T) {
 		client := newTestClient(t)
 
@@ -182,8 +208,13 @@ func TestClient_GetCapabilities(t *testing.T) {
 
 // mockCapabilities is used for mocking the response
 func mockCapabilities(statusCode int) {
+	mockCapabilitiesNetwork(statusCode, Mainnet)
+}
+
+// mockCapabilitiesNetwork is used for mocking the response on a specific network
+func mockCapabilitiesNetwork(statusCode int, n Network) {
 	httpmock.Reset()
-	httpmock.RegisterResponder(http.MethodGet, "https://"+testDomain+":443/.well-known/"+DefaultServiceName,
+	httpmock.RegisterResponder(http.MethodGet, "https://"+testDomain+":443/.well-known/"+DefaultServiceName+n.PaymailURLSuffix(),
 		httpmock.NewStringResponder(
 			statusCode,
 			`{"`+DefaultServiceName+`": "`+DefaultBsvAliasVersion+`","capabilities": 

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ type ClientOptions struct {
 	sslDeadline       time.Duration // Default timeout in seconds for SSL deadline
 	sslTimeout        time.Duration // Default timeout in seconds for SSL timeout
 	userAgent         string        // User agent for all outgoing requests
+	network           Network       // The bitcoin network to operate on
 }
 
 // ClientOps allow functional options to be supplied

--- a/client_options.go
+++ b/client_options.go
@@ -23,6 +23,7 @@ func defaultClientOptions() (opts *ClientOptions, err error) {
 		sslDeadline:       defaultSSLDeadline,
 		sslTimeout:        defaultSSLTimeout,
 		userAgent:         defaultUserAgent,
+		network:           Network(defaultNetwork),
 	}
 
 	// Load the default BRFC specs
@@ -115,6 +116,14 @@ func WithSSLDeadline(timeout time.Duration) ClientOps {
 func WithUserAgent(userAgent string) ClientOps {
 	return func(c *ClientOptions) {
 		c.userAgent = userAgent
+	}
+}
+
+// WithNetwork will set the client's operational network to one provided.
+// Default is mainnet.
+func WithNetwork(n Network) ClientOps {
+	return func(c *ClientOptions) {
+		c.network = n
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // newTestClient will return a client for testing purposes
-func newTestClient(t *testing.T) ClientInterface {
+func newTestClient(t *testing.T, opts ...ClientOps) ClientInterface {
 
 	// Create a Resty Client
 	httpClient := tester.MockResty()
@@ -22,7 +22,7 @@ func newTestClient(t *testing.T) ClientInterface {
 	}
 
 	// Create a new client
-	client, err := NewClient(WithRequestTracing(), WithDNSTimeout(15*time.Second))
+	client, err := NewClient(append([]ClientOps{WithRequestTracing(), WithDNSTimeout(15 * time.Second)}, opts...)...)
 	if t != nil {
 		require.NotNil(t, client)
 		require.NoError(t, err)

--- a/definitions.go
+++ b/definitions.go
@@ -17,6 +17,7 @@ const (
 	defaultSSLDeadline       = 10 * time.Second         // Default deadline in seconds
 	defaultSSLTimeout        = 10 * time.Second         // Default timeout in seconds
 	defaultUserAgent         = "go-paymail: " + version // Default user agent
+	defaultNetwork           = byte(Mainnet)            // Default network
 	version                  = "v0.6.0"                 // Go-Paymail version
 )
 

--- a/networks.go
+++ b/networks.go
@@ -1,0 +1,41 @@
+package paymail
+
+// Network an alias of the bitcoin networks.
+type Network byte
+
+const (
+	// Mainnet bitcoin main network.
+	Mainnet Network = iota
+	// Testnet bitcoin test network.
+	Testnet
+	// STN bitcoin stress test network.
+	STN
+)
+
+// String representation of the network.
+func (n Network) String() string {
+	switch n {
+	case Mainnet:
+		return "mainnet"
+	case Testnet:
+		return "testnet"
+	case STN:
+		return "STN"
+	default:
+		return "not recognized"
+	}
+}
+
+// PaymailURLSuffix the conventional URL suffix for the network.
+func (n Network) PaymailURLSuffix() string {
+	switch n {
+	case Testnet:
+		return "-testnet"
+	case STN:
+		return "-stn"
+	case Mainnet:
+		return ""
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Add support for paymail over different networks.

I have added the following:
- Introduce a `Network` type for distinguishing between the different bitcoin networks.
- Give each `Network` a paymail url suffix.
- Add this suffix to the built capabilities endpoint.
- Added tests.